### PR TITLE
Handle wallet provider events, auto init wallet connect

### DIFF
--- a/src/stores/metamask.ts
+++ b/src/stores/metamask.ts
@@ -1,5 +1,6 @@
 import detectEthereumProvider from "@metamask/detect-provider";
 import { providers } from "ethers";
+import walletStore from "./wallet";
 
 function createMetamaskStore() {
   async function connect(showPrompt?: boolean) {
@@ -13,6 +14,8 @@ function createMetamaskStore() {
     const signer = provider.getSigner();
     const userAddress = await signer.getAddress();
 
+    setupEventListeners(web3Provider);
+
     return {
       signer,
       userAddress,
@@ -20,8 +23,18 @@ function createMetamaskStore() {
     };
   }
 
-  async function setupMetamask() {
+  function setupEventListeners(provider: any) {
+    // Subscribe to accounts change
+    provider.on("accountsChanged", walletStore.handleAccountChange);
+
+    // Subscribe to accounts change
+    provider.on("chainChanged", walletStore.handleChainChange);
+  }
+
+  async function init() {
     if ((window.ethereum as any).selectedAddress) {
+      console.log((window.ethereum as any).selectedAddress);
+
       return connect(true);
     }
 
@@ -30,7 +43,7 @@ function createMetamaskStore() {
 
   return {
     connect,
-    setupMetamask,
+    init,
   };
 }
 

--- a/src/stores/metamask.ts
+++ b/src/stores/metamask.ts
@@ -33,8 +33,6 @@ function createMetamaskStore() {
 
   async function init() {
     if ((window.ethereum as any).selectedAddress) {
-      console.log((window.ethereum as any).selectedAddress);
-
       return connect(true);
     }
 

--- a/src/stores/walletConnect.ts
+++ b/src/stores/walletConnect.ts
@@ -1,5 +1,6 @@
 import { providers, Signer } from "ethers";
 import WalletConnectProvider from "@walletconnect/web3-provider";
+import walletStore from "./wallet";
 
 function createWalletConnectStore() {
   async function connect() {
@@ -14,6 +15,8 @@ function createWalletConnectStore() {
 
     web3Provider.updateRpcUrl(69);
 
+    setupEventListeners(web3Provider);
+
     const provider = new providers.Web3Provider(web3Provider);
     const signer = provider.getSigner();
     const userAddress = await signer.getAddress();
@@ -25,8 +28,30 @@ function createWalletConnectStore() {
     };
   }
 
+  function setupEventListeners(provider: any) {
+    // Subscribe to accounts change
+    provider.on("accountsChanged", walletStore.handleAccountChange);
+
+    // Subscribe to accounts change
+    provider.on("chainChanged", walletStore.handleChainChange);
+
+    // Subscribe to session disconnection
+    provider.on("disconnect", walletStore.handleProviderDisconnect);
+  }
+
+  async function init() {
+    const stored = localStorage.getItem("walletconnect");
+
+    if (stored) {
+      return connect();
+    }
+
+    return null;
+  }
+
   return {
     connect,
+    init,
   };
 }
 


### PR DESCRIPTION
Why:
 - Provider events (chain change, accounts change, disconnect) are being ignored.

How:
 - Add event listeners to metamask and wallet connect providers (not the `ethers.js` provider class)
 - Also, if wallet connect is already, automatically connect, like we do with metamask.
 - Chain change event is detected but we're not doing anything with it yet, as that will depend on the contracts part.

Note: When you disconnect a Metamask wallet, it emits an `accountsChanged` event with an empty array, but when you end a Wallet Connect session, it emits a  `disconnect` event.